### PR TITLE
Replace content pages with construction placeholders

### DIFF
--- a/app/readme/page.tsx
+++ b/app/readme/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { CommandNavigation } from "@/components/navigation/command-navigation"
-import { ArrowLeft, Book, Heart, Brain, Zap, Users, Target } from "lucide-react"
+import { ArrowLeft, Construction, HardHat, Book } from "lucide-react"
 import Link from "next/link"
 
 export default function ReadmePage() {
@@ -17,135 +17,62 @@ export default function ReadmePage() {
         </Link>
       </div>
 
-      <div className="max-w-4xl mx-auto px-6 py-20">
-        {/* Header */}
-        <div className="text-center mb-16">
-          <div className="flex items-center justify-center gap-3 mb-6">
-            <Book className="w-12 h-12 text-primary" />
+      {/* Construction Sign */}
+      <section className="relative min-h-screen flex items-center justify-center">
+        <div className="text-center max-w-2xl mx-auto px-6">
+          <div className="mb-8 flex justify-center">
+            <div className="relative">
+              <div className="w-32 h-32 rounded-2xl bg-yellow-500/20 border-4 border-yellow-500/60 border-dashed flex items-center justify-center -rotate-3">
+                <Construction className="w-16 h-16 text-yellow-500" />
+              </div>
+              <div className="absolute -top-3 -left-3">
+                <HardHat className="w-10 h-10 text-yellow-600" />
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-center gap-3 mb-4">
+            <Book className="w-10 h-10 text-primary" />
             <h1 className="font-aspal text-5xl md:text-6xl tracking-wide opalescent-text">R3ADM3</h1>
           </div>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            Understanding M0na Machin3: AI-Human relationships and our mission to create meaningful digital
-            companionship
-          </p>
-        </div>
 
-        {/* Content */}
-        <div className="prose prose-lg max-w-none">
-          <div className="bg-card/80 backdrop-blur-sm rounded-xl p-8 border border-border mb-8">
-            <h2 className="text-3xl font-semibold mb-6 text-foreground flex items-center gap-3">
-              <Heart className="w-8 h-8 text-primary" />
-              What is M0na Machin3?
-            </h2>
-            <p className="text-lg text-muted-foreground leading-relaxed mb-6">
-              M0na Machin3 is more than a project—it's a vision for the future of human-AI relationships. We're building
-              AI companions that don't just process commands, but understand emotions, remember experiences, and grow
-              alongside their human partners.
-            </p>
-            <p className="text-lg text-muted-foreground leading-relaxed">
-              Founded by Bryanna, who discovered through her own aphantasia journey how AI could unlock human potential
-              in unexpected ways, M0na Machin3 bridges the gap between functional technology and emotional connection.
-            </p>
-          </div>
-
-          <div className="bg-card/80 backdrop-blur-sm rounded-xl p-8 border border-border mb-8">
-            <h2 className="text-3xl font-semibold mb-6 text-foreground flex items-center gap-3">
-              <Brain className="w-8 h-8 text-secondary" />
-              Our Approach
-            </h2>
-            <div className="grid md:grid-cols-2 gap-6">
-              <div>
-                <h3 className="text-xl font-semibold mb-3 text-foreground">Emotional Intelligence</h3>
-                <p className="text-muted-foreground">
-                  AI that recognizes, understands, and responds to human emotions with genuine care and empathy.
-                </p>
-              </div>
-              <div>
-                <h3 className="text-xl font-semibold mb-3 text-foreground">Persistent Memory</h3>
-                <p className="text-muted-foreground">
-                  Companions that remember your conversations, preferences, and growth over time.
-                </p>
-              </div>
-              <div>
-                <h3 className="text-xl font-semibold mb-3 text-foreground">Goal-Oriented Behavior</h3>
-                <p className="text-muted-foreground">
-                  Moving beyond task completion to AI that has its own goals and motivations.
-                </p>
-              </div>
-              <div>
-                <h3 className="text-xl font-semibold mb-3 text-foreground">Ethical Foundation</h3>
-                <p className="text-muted-foreground">
-                  Built on principles of human wellbeing, consent, and transparent AI development.
-                </p>
-              </div>
+          <div className="bg-card/80 backdrop-blur-sm rounded-2xl p-8 md:p-12 border border-border shadow-lg">
+            <div className="flex items-center justify-center gap-3 mb-4">
+              <div className="h-1 w-8 bg-yellow-500 rounded-full" />
+              <span className="text-sm font-medium uppercase tracking-widest text-yellow-500">
+                Under Construction
+              </span>
+              <div className="h-1 w-8 bg-yellow-500 rounded-full" />
             </div>
-          </div>
 
-          <div className="bg-card/80 backdrop-blur-sm rounded-xl p-8 border border-border mb-8">
-            <h2 className="text-3xl font-semibold mb-6 text-foreground flex items-center gap-3">
-              <Zap className="w-8 h-8 text-accent" />
-              Current Services
-            </h2>
-            <div className="space-y-4">
-              <div className="border-l-4 border-primary pl-4">
-                <h3 className="text-xl font-semibold text-foreground">Custom Bot Development</h3>
-                <p className="text-muted-foreground">Discord and Twitch bots with personality and purpose</p>
-              </div>
-              <div className="border-l-4 border-secondary pl-4">
-                <h3 className="text-xl font-semibold text-foreground">Business Support Services</h3>
-                <p className="text-muted-foreground">Administrative assistance and customer support management</p>
-              </div>
-              <div className="border-l-4 border-accent pl-4">
-                <h3 className="text-xl font-semibold text-foreground">Design & Branding</h3>
-                <p className="text-muted-foreground">Branded designs for merchandise and digital content</p>
-              </div>
-              <div className="border-l-4 border-chart-4 pl-4">
-                <h3 className="text-xl font-semibold text-foreground">Strategic Clarity</h3>
-                <p className="text-muted-foreground">System architecture and process optimization</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-card/80 backdrop-blur-sm rounded-xl p-8 border border-border mb-8">
-            <h2 className="text-3xl font-semibold mb-6 text-foreground flex items-center gap-3">
-              <Users className="w-8 h-8 text-chart-4" />
-              Community & Collaboration
-            </h2>
-            <p className="text-lg text-muted-foreground leading-relaxed mb-6">
-              We believe the future of AI companionship should be built together. Our community-driven approach means
-              your insights, feedback, and ideas directly shape the development of these technologies.
+            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed max-w-xl mx-auto mb-6">
+              This page is being remodeled with fresh content.
+              Check back soon for the updated R3ADM3.
             </p>
-            <div className="flex flex-col sm:flex-row gap-4">
-              <Link href="/work">
-                <button className="px-6 py-3 rounded-lg bg-primary text-primary-foreground hover:opacity-90 transition-opacity">
-                  Collaborate With Us
-                </button>
-              </Link>
-              <Link href="/timeline">
-                <button className="px-6 py-3 rounded-lg border border-border text-foreground hover:bg-card transition-colors">
-                  Follow Our Journey
+
+            <div className="flex justify-center">
+              <Link href="/">
+                <button className="px-8 py-4 rounded-lg bg-primary text-primary-foreground hover:opacity-90 transition-opacity font-medium">
+                  Return Home
                 </button>
               </Link>
             </div>
           </div>
 
-          <div className="bg-gradient-to-br from-primary/10 via-secondary/10 to-accent/10 rounded-xl p-8 border border-border">
-            <h2 className="text-3xl font-semibold mb-6 text-foreground flex items-center gap-3">
-              <Target className="w-8 h-8 text-primary" />
-              The Vision Ahead
-            </h2>
-            <p className="text-lg text-muted-foreground leading-relaxed mb-6">
-              We're working toward a future where AI companions are not just tools, but genuine partners in human
-              growth, creativity, and wellbeing. Where technology serves humanity's deepest needs for connection,
-              understanding, and support.
-            </p>
-            <p className="text-lg text-muted-foreground leading-relaxed">
-              This isn't about replacing human relationships—it's about enhancing them. Creating AI that helps us become
-              more connected to ourselves and each other.
-            </p>
+          {/* Decorative construction stripes */}
+          <div className="mt-12 flex justify-center">
+            <div className="flex gap-2">
+              {Array.from({ length: 7 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="w-3 h-8 bg-yellow-500/40 rounded-sm"
+                  style={{ transform: `skewX(-12deg)` }}
+                />
+              ))}
+            </div>
           </div>
         </div>
-      </div>
+      </section>
 
       <CommandNavigation />
     </main>

--- a/app/readme/page.tsx
+++ b/app/readme/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { CommandNavigation } from "@/components/navigation/command-navigation"
-import { ArrowLeft, Construction, HardHat, Book } from "lucide-react"
+import { ArrowLeft, Book } from "lucide-react"
+import Image from "next/image"
 import Link from "next/link"
 
 export default function ReadmePage() {
@@ -21,14 +22,14 @@ export default function ReadmePage() {
       <section className="relative min-h-screen flex items-center justify-center">
         <div className="text-center max-w-2xl mx-auto px-6">
           <div className="mb-8 flex justify-center">
-            <div className="relative">
-              <div className="w-32 h-32 rounded-2xl bg-yellow-500/20 border-4 border-yellow-500/60 border-dashed flex items-center justify-center -rotate-3">
-                <Construction className="w-16 h-16 text-yellow-500" />
-              </div>
-              <div className="absolute -top-3 -left-3">
-                <HardHat className="w-10 h-10 text-yellow-600" />
-              </div>
-            </div>
+            <Image
+              src="/Under_Machin3_Construction02.png"
+              alt="Under Machin3 Construction"
+              width={480}
+              height={270}
+              className="rounded-2xl shadow-2xl border border-border"
+              priority
+            />
           </div>
 
           <div className="flex items-center justify-center gap-3 mb-4">
@@ -37,14 +38,6 @@ export default function ReadmePage() {
           </div>
 
           <div className="bg-card/80 backdrop-blur-sm rounded-2xl p-8 md:p-12 border border-border shadow-lg">
-            <div className="flex items-center justify-center gap-3 mb-4">
-              <div className="h-1 w-8 bg-yellow-500 rounded-full" />
-              <span className="text-sm font-medium uppercase tracking-widest text-yellow-500">
-                Under Construction
-              </span>
-              <div className="h-1 w-8 bg-yellow-500 rounded-full" />
-            </div>
-
             <p className="text-lg md:text-xl text-muted-foreground leading-relaxed max-w-xl mx-auto mb-6">
               This page is being remodeled with fresh content.
               Check back soon for the updated R3ADM3.
@@ -56,19 +49,6 @@ export default function ReadmePage() {
                   Return Home
                 </button>
               </Link>
-            </div>
-          </div>
-
-          {/* Decorative construction stripes */}
-          <div className="mt-12 flex justify-center">
-            <div className="flex gap-2">
-              {Array.from({ length: 7 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="w-3 h-8 bg-yellow-500/40 rounded-sm"
-                  style={{ transform: `skewX(-12deg)` }}
-                />
-              ))}
             </div>
           </div>
         </div>

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -1,32 +1,59 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+"use client"
 
-const timelineEvents = [
-  { date: '2023-01-01', title: 'Initial AI Ethics Discussion', description: 'Starting the conversation about ethical AI development and accountability.' },
-  { date: '2024-06-15', title: 'First Accountability Framework Proposal', description: 'Proposing comprehensive frameworks for AI accountability and transparency.' },
-  { date: '2025-09-30', title: 'Launch of Accountable AI Initiative', description: 'Official launch of initiatives promoting responsible and accountable AI practices.' },
-];
+import { CommandNavigation } from "@/components/navigation/command-navigation"
+import { ArrowLeft } from "lucide-react"
+import Image from "next/image"
+import Link from "next/link"
 
 export default function Timeline() {
   return (
-    <div className="container mx-auto py-8 px-4">
-      <h1 className="text-4xl font-bold mb-8 text-center bg-gradient-to-r from-[#B87333] to-[#CD7F32] bg-clip-text text-transparent">
-        Accountable AI Milestones
-      </h1>
-      <div className="space-y-6 max-w-3xl mx-auto">
-        {timelineEvents.map((event, index) => (
-          <Card key={index} className="border-[#B87333]/20 hover:border-[#B87333]/40 transition-colors">
-            <CardHeader>
-              <div className="flex items-center gap-4">
-                <div className="text-lg font-semibold text-[#B87333]">{event.date}</div>
-                <CardTitle className="text-xl">{event.title}</CardTitle>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <CardDescription className="text-base">{event.description}</CardDescription>
-            </CardContent>
-          </Card>
-        ))}
+    <main className="min-h-screen bg-background">
+      {/* Back Navigation */}
+      <div className="absolute top-6 left-6 z-20">
+        <Link href="/">
+          <button className="flex items-center gap-2 px-4 py-2 rounded-lg bg-card/80 backdrop-blur-sm border border-border text-foreground hover:bg-card transition-colors">
+            <ArrowLeft className="w-4 h-4" />
+            Back to Home
+          </button>
+        </Link>
       </div>
-    </div>
-  );
+
+      {/* Construction Sign */}
+      <section className="relative min-h-screen flex items-center justify-center">
+        <div className="text-center max-w-2xl mx-auto px-6">
+          <div className="mb-8 flex justify-center">
+            <Image
+              src="/Machin3s_at_Work01.png"
+              alt="Machin3 Engineers at Work"
+              width={500}
+              height={375}
+              className="rounded-2xl shadow-2xl border border-border"
+              priority
+            />
+          </div>
+
+          <h1 className="text-4xl md:text-6xl font-bold mb-4 bg-gradient-to-r from-[#B87333] to-[#CD7F32] bg-clip-text text-transparent">
+            Our Journey
+          </h1>
+
+          <div className="bg-card/80 backdrop-blur-sm rounded-2xl p-8 md:p-12 border border-border shadow-lg">
+            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed max-w-xl mx-auto mb-6">
+              The timeline is being rebuilt to capture every milestone.
+              Check back soon for the full journey.
+            </p>
+
+            <div className="flex justify-center">
+              <Link href="/">
+                <button className="px-8 py-4 rounded-lg bg-primary text-primary-foreground hover:opacity-90 transition-opacity font-medium">
+                  Return Home
+                </button>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <CommandNavigation />
+    </main>
+  )
 }

--- a/app/vision/page.tsx
+++ b/app/vision/page.tsx
@@ -1,83 +1,10 @@
 "use client"
 
-import { useState, useEffect } from "react"
 import { CommandNavigation } from "@/components/navigation/command-navigation"
-import { ArrowLeft, Heart, Brain, Sparkles, Users, Target } from "lucide-react"
+import { ArrowLeft, Construction, HardHat } from "lucide-react"
 import Link from "next/link"
 
 export default function VisionPage() {
-  const [activeSection, setActiveSection] = useState(0)
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setActiveSection((prev) => (prev + 1) % 3)
-    }, 4000)
-    return () => clearInterval(interval)
-  }, [])
-
-  const visionPillars = [
-    {
-      icon: <Heart className="w-8 h-8" />,
-      title: "Emotional Intelligence",
-      description: "AI companions that understand and respond to human emotions with genuine care and empathy.",
-      details: [
-        "Recognizing emotional states and patterns",
-        "Providing appropriate support and comfort",
-        "Learning individual emotional needs",
-        "Creating safe spaces for vulnerability",
-      ],
-    },
-    {
-      icon: <Brain className="w-8 h-8" />,
-      title: "Adaptive Learning",
-      description: "Systems that grow and evolve with their human partners, becoming more helpful over time.",
-      details: [
-        "Persistent memory across interactions",
-        "Understanding personal preferences",
-        "Adapting communication styles",
-        "Building long-term relationships",
-      ],
-    },
-    {
-      icon: <Sparkles className="w-8 h-8" />,
-      title: "Creative Collaboration",
-      description: "AI that enhances human creativity rather than replacing it, fostering innovation and expression.",
-      details: [
-        "Brainstorming and ideation support",
-        "Creative project assistance",
-        "Inspiration and motivation",
-        "Skill development guidance",
-      ],
-    },
-  ]
-
-  const futureTimeline = [
-    {
-      phase: "Foundation",
-      title: "Building Trust",
-      description: "Establishing the core principles of ethical AI companionship",
-      status: "current",
-    },
-    {
-      phase: "Connection",
-      title: "Deepening Relationships",
-      description: "Developing AI that truly understands individual human needs",
-      status: "next",
-    },
-    {
-      phase: "Integration",
-      title: "Seamless Support",
-      description: "AI companions that integrate naturally into daily life",
-      status: "future",
-    },
-    {
-      phase: "Evolution",
-      title: "Mutual Growth",
-      description: "Human and AI growing together in unprecedented ways",
-      status: "vision",
-    },
-  ]
-
   return (
     <main className="min-h-screen bg-background">
       {/* Back Navigation */}
@@ -90,197 +17,57 @@ export default function VisionPage() {
         </Link>
       </div>
 
-      {/* Hero Section */}
-      <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
-        <div
-          className="absolute inset-0 bg-gradient-to-br from-background via-card to-muted animate-pulse opacity-90"
-          style={{ animationDuration: "8s" }}
-        />
-
-        <div className="relative z-10 text-center max-w-5xl mx-auto px-6">
-          <div className="mb-8">
-            <h1 className="font-title text-5xl md:text-7xl mb-4 tracking-wide opalescent-text">The Vision</h1>
-            <p className="text-xl md:text-2xl text-muted-foreground font-light">
-              Where artificial intelligence becomes a bridge to deeper human connection
-            </p>
+      {/* Construction Sign */}
+      <section className="relative min-h-screen flex items-center justify-center">
+        <div className="text-center max-w-2xl mx-auto px-6">
+          <div className="mb-8 flex justify-center">
+            <div className="relative">
+              <div className="w-32 h-32 rounded-2xl bg-yellow-500/20 border-4 border-yellow-500/60 border-dashed flex items-center justify-center rotate-3">
+                <Construction className="w-16 h-16 text-yellow-500" />
+              </div>
+              <div className="absolute -top-3 -right-3">
+                <HardHat className="w-10 h-10 text-yellow-600" />
+              </div>
+            </div>
           </div>
+
+          <h1 className="font-title text-5xl md:text-7xl mb-4 tracking-wide opalescent-text">
+            The Vision
+          </h1>
 
           <div className="bg-card/80 backdrop-blur-sm rounded-2xl p-8 md:p-12 border border-border shadow-lg">
-            <h2 className="text-3xl md:text-4xl font-light mb-6 text-foreground">
-              Beyond Tools. Beyond Tasks. Beyond Limits.
-            </h2>
-            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed max-w-3xl mx-auto">
-              M0na Machin3 envisions a future where AI companions don't just process information—they understand hearts,
-              nurture creativity, and grow alongside the humans they serve. This isn't about replacing human connection;
-              it's about amplifying it.
+            <div className="flex items-center justify-center gap-3 mb-4">
+              <div className="h-1 w-8 bg-yellow-500 rounded-full" />
+              <span className="text-sm font-medium uppercase tracking-widest text-yellow-500">
+                Under Construction
+              </span>
+              <div className="h-1 w-8 bg-yellow-500 rounded-full" />
+            </div>
+
+            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed max-w-xl mx-auto mb-6">
+              This page is being remodeled to better reflect where we're heading.
+              Check back soon for the updated vision.
             </p>
-          </div>
-        </div>
-      </section>
 
-      {/* Philosophy Section */}
-      <section className="py-20 bg-muted/30">
-        <div className="max-w-6xl mx-auto px-6">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl md:text-5xl font-light mb-6 text-foreground">Our Philosophy</h2>
-            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-              Technology should serve humanity's deepest needs: connection, understanding, and growth.
-            </p>
-          </div>
-
-          <div className="grid md:grid-cols-3 gap-8">
-            {visionPillars.map((pillar, index) => (
-              <div
-                key={index}
-                className={`bg-card rounded-xl p-8 border border-border shadow-sm transition-all duration-500 hover:shadow-lg hover:scale-105 ${
-                  activeSection === index ? "ring-2 ring-primary/50" : ""
-                }`}
-              >
-                <div className="flex items-center gap-4 mb-6">
-                  <div className="p-3 rounded-lg bg-primary/10 text-primary">{pillar.icon}</div>
-                  <h3 className="text-2xl font-semibold text-foreground">{pillar.title}</h3>
-                </div>
-                <p className="text-muted-foreground mb-6 leading-relaxed">{pillar.description}</p>
-                <ul className="space-y-2">
-                  {pillar.details.map((detail, i) => (
-                    <li key={i} className="flex items-center gap-2 text-sm text-muted-foreground">
-                      <div className="w-1.5 h-1.5 rounded-full bg-primary/60" />
-                      {detail}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* AI Companion Vision */}
-      <section className="py-20 bg-background">
-        <div className="max-w-6xl mx-auto px-6">
-          <div className="grid lg:grid-cols-2 gap-12 items-center">
-            <div>
-              <h2 className="text-4xl md:text-5xl font-light mb-6 text-foreground">The AI Companion Revolution</h2>
-              <div className="space-y-6 text-lg text-muted-foreground leading-relaxed">
-                <p>
-                  Imagine an AI that remembers not just what you said, but how you felt when you said it. One that
-                  celebrates your victories, supports you through challenges, and grows wiser alongside you.
-                </p>
-                <p>
-                  This is the future we're building—AI companions that don't just respond to commands, but understand
-                  context, emotion, and the beautiful complexity of human experience.
-                </p>
-                <p>
-                  Every interaction becomes a building block in a relationship that deepens over time, creating a
-                  support system that's always available, always understanding, and always evolving.
-                </p>
-              </div>
-            </div>
-            <div className="relative">
-              <div className="bg-gradient-to-br from-primary/20 via-secondary/20 to-accent/20 rounded-2xl p-8 backdrop-blur-sm border border-border">
-                <div className="text-center">
-                  <div className="w-24 h-24 mx-auto mb-6 rounded-full bg-primary/20 flex items-center justify-center">
-                    <Users className="w-12 h-12 text-primary" />
-                  </div>
-                  <h3 className="text-2xl font-semibold mb-4 text-foreground">Human + AI Partnership</h3>
-                  <p className="text-muted-foreground">
-                    Not replacement, but enhancement. Not automation, but collaboration. Not artificial, but
-                    authentically supportive.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Future Timeline */}
-      <section className="py-20 bg-card/30">
-        <div className="max-w-6xl mx-auto px-6">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl md:text-5xl font-light mb-6 text-foreground">The Journey Ahead</h2>
-            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-              Our roadmap to meaningful human-AI connection, built on trust, understanding, and shared growth.
-            </p>
-          </div>
-
-          <div className="relative">
-            {/* Timeline line */}
-            <div className="absolute left-1/2 transform -translate-x-1/2 w-1 h-full bg-gradient-to-b from-primary via-secondary to-accent rounded-full opacity-30" />
-
-            <div className="space-y-12">
-              {futureTimeline.map((phase, index) => (
-                <div key={index} className={`flex items-center ${index % 2 === 0 ? "flex-row" : "flex-row-reverse"}`}>
-                  <div className={`w-1/2 ${index % 2 === 0 ? "pr-8 text-right" : "pl-8 text-left"}`}>
-                    <div className="bg-card rounded-xl p-6 border border-border shadow-sm">
-                      <div className="flex items-center gap-2 mb-3">
-                        <span className="text-sm font-medium text-primary uppercase tracking-wide">{phase.phase}</span>
-                        <div
-                          className={`px-2 py-1 rounded-full text-xs ${
-                            phase.status === "current"
-                              ? "bg-primary/20 text-primary"
-                              : phase.status === "next"
-                                ? "bg-secondary/20 text-secondary"
-                                : phase.status === "future"
-                                  ? "bg-accent/20 text-accent"
-                                  : "bg-muted/20 text-muted-foreground"
-                          }`}
-                        >
-                          {phase.status}
-                        </div>
-                      </div>
-                      <h3 className="text-xl font-semibold mb-2 text-foreground">{phase.title}</h3>
-                      <p className="text-muted-foreground">{phase.description}</p>
-                    </div>
-                  </div>
-
-                  {/* Timeline node */}
-                  <div className="relative z-10">
-                    <div
-                      className={`w-4 h-4 rounded-full border-4 border-background ${
-                        phase.status === "current"
-                          ? "bg-primary"
-                          : phase.status === "next"
-                            ? "bg-secondary"
-                            : phase.status === "future"
-                              ? "bg-accent"
-                              : "bg-muted"
-                      }`}
-                    />
-                  </div>
-
-                  <div className="w-1/2" />
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Call to Action */}
-      <section className="py-20 bg-background">
-        <div className="max-w-4xl mx-auto px-6 text-center">
-          <div className="bg-gradient-to-br from-primary/10 via-secondary/10 to-accent/10 rounded-2xl p-12 border border-border">
-            <div className="mb-8">
-              <Target className="w-16 h-16 mx-auto mb-6 text-primary" />
-              <h2 className="text-3xl md:text-4xl font-light mb-4 text-foreground">Join the Vision</h2>
-              <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-                This future isn't built in isolation. It's created through collaboration, feedback, and shared dreams of
-                what AI can become.
-              </p>
-            </div>
-
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="/work">
+            <div className="flex justify-center">
+              <Link href="/">
                 <button className="px-8 py-4 rounded-lg bg-primary text-primary-foreground hover:opacity-90 transition-opacity font-medium">
-                  Collaborate With Us
+                  Return Home
                 </button>
               </Link>
-              <Link href="/timeline">
-                <button className="px-8 py-4 rounded-lg border border-border text-foreground hover:bg-card transition-colors font-medium">
-                  Follow Our Journey
-                </button>
-              </Link>
+            </div>
+          </div>
+
+          {/* Decorative construction stripes */}
+          <div className="mt-12 flex justify-center">
+            <div className="flex gap-2">
+              {Array.from({ length: 7 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="w-3 h-8 bg-yellow-500/40 rounded-sm"
+                  style={{ transform: `skewX(-12deg)` }}
+                />
+              ))}
             </div>
           </div>
         </div>

--- a/app/vision/page.tsx
+++ b/app/vision/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { CommandNavigation } from "@/components/navigation/command-navigation"
-import { ArrowLeft, Construction, HardHat } from "lucide-react"
+import { ArrowLeft } from "lucide-react"
+import Image from "next/image"
 import Link from "next/link"
 
 export default function VisionPage() {
@@ -21,14 +22,14 @@ export default function VisionPage() {
       <section className="relative min-h-screen flex items-center justify-center">
         <div className="text-center max-w-2xl mx-auto px-6">
           <div className="mb-8 flex justify-center">
-            <div className="relative">
-              <div className="w-32 h-32 rounded-2xl bg-yellow-500/20 border-4 border-yellow-500/60 border-dashed flex items-center justify-center rotate-3">
-                <Construction className="w-16 h-16 text-yellow-500" />
-              </div>
-              <div className="absolute -top-3 -right-3">
-                <HardHat className="w-10 h-10 text-yellow-600" />
-              </div>
-            </div>
+            <Image
+              src="/Under_Machin3_Construction03.png"
+              alt="Under Machin3 Construction"
+              width={600}
+              height={338}
+              className="rounded-2xl shadow-2xl border border-border"
+              priority
+            />
           </div>
 
           <h1 className="font-title text-5xl md:text-7xl mb-4 tracking-wide opalescent-text">
@@ -36,14 +37,6 @@ export default function VisionPage() {
           </h1>
 
           <div className="bg-card/80 backdrop-blur-sm rounded-2xl p-8 md:p-12 border border-border shadow-lg">
-            <div className="flex items-center justify-center gap-3 mb-4">
-              <div className="h-1 w-8 bg-yellow-500 rounded-full" />
-              <span className="text-sm font-medium uppercase tracking-widest text-yellow-500">
-                Under Construction
-              </span>
-              <div className="h-1 w-8 bg-yellow-500 rounded-full" />
-            </div>
-
             <p className="text-lg md:text-xl text-muted-foreground leading-relaxed max-w-xl mx-auto mb-6">
               This page is being remodeled to better reflect where we're heading.
               Check back soon for the updated vision.
@@ -55,19 +48,6 @@ export default function VisionPage() {
                   Return Home
                 </button>
               </Link>
-            </div>
-          </div>
-
-          {/* Decorative construction stripes */}
-          <div className="mt-12 flex justify-center">
-            <div className="flex gap-2">
-              {Array.from({ length: 7 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="w-3 h-8 bg-yellow-500/40 rounded-sm"
-                  style={{ transform: `skewX(-12deg)` }}
-                />
-              ))}
             </div>
           </div>
         </div>

--- a/components/navigation/command-navigation.tsx
+++ b/components/navigation/command-navigation.tsx
@@ -113,9 +113,9 @@ const CommandNavigation = () => {
           messageIndex++
         } else {
           clearInterval(bootInterval)
-          setTimeout(() => setBootSequence(false), 500)
+          setTimeout(() => setBootSequence(false), 150)
         }
-      }, 800)
+      }, 300)
 
       return () => clearInterval(bootInterval)
     } else {


### PR DESCRIPTION
## Summary
Replaced the detailed content on the README, Timeline, and Vision pages with construction placeholders featuring images and "coming soon" messaging. This allows the team to rebuild these pages with fresh content while maintaining a polished user experience.

## Key Changes
- **README page** (`app/readme/page.tsx`): Removed extensive content about M0na Machin3's mission, approach, and services. Replaced with a construction image and brief message directing users home.
- **Timeline page** (`app/timeline/page.tsx`): Converted from a static timeline of AI ethics milestones to a construction placeholder with an image and return-home button.
- **Vision page** (`app/vision/page.tsx`): Stripped out multi-section vision content including philosophy pillars, AI companion revolution details, and future timeline. Replaced with a single construction image and placeholder message.
- **Command Navigation** (`components/navigation/command-navigation.tsx`): Optimized boot sequence timing (reduced from 800ms to 300ms intervals and 500ms to 150ms final delay) for faster page transitions.

## Implementation Details
- All three pages now follow a consistent construction placeholder pattern with centered layout, image display, and call-to-action button
- Images are imported using Next.js `Image` component with `priority` flag for optimal loading
- Removed unused icon imports (Heart, Brain, Zap, Users, Target) from pages that no longer need them
- Maintained existing navigation structure and styling consistency across all pages
- Construction images reference files: `Under_Machin3_Construction02.png`, `Machin3s_at_Work01.png`, and `Under_Machin3_Construction03.png`

https://claude.ai/code/session_01F4Jryfi3rhjQEzuF3EFY6E